### PR TITLE
Изменил ник Ильи Пухальского в твиттере

### DIFF
--- a/2013/06/08/index.htm
+++ b/2013/06/08/index.htm
@@ -209,7 +209,7 @@
 					</dd>
 				</dl>
 				<dl id="ilya-pukhalski" class="card">
-					<dt>Илья Пухальский <a href="http://twitter.com/witchfinderx">@witchfinderx</a></dt>
+					<dt>Илья Пухальский <a href="http://twitter.com/pukhalski">@pukhalski</a></dt>
 					<dd>
 						<img src="/speakers/ilya.pukhalski.jpg" alt="Илья Пухальский">
 						Solution Architect в компании <a href="http://www.epam-group.ru/">EPAM Systems</a>. Веб-разработчик с более чем шестилетним опытом, JavaScript-lover. Текущая страсть — разработка мобильных приложений и сайтов.


### PR DESCRIPTION
Илья поменял ник в твиттере, пусть всем будет 200, а не 404.
