### PR TITLE
Замена хоста получения твитов

### DIFF
--- a/j/script.js
+++ b/j/script.js
@@ -7,8 +7,7 @@ $(function(){
 	$.fn.tweets = function( q ) {
 		var list = $( this ),
 			url;
-		url = 'http://twitter.webstandardsdays.ru/?callback=?';
-		console.log(url);
+		url = 'http://twitter.webstandardsdays.ru/?fields=user.screen_name,user.profile_image_url,text&callback=?';
 
 		$.getJSON( url, function( data ) {
 			$.each( data, function( i, item ) {


### PR DESCRIPTION
Вместо накрывшегося search.twitter.com используем самодельный проксик http://twitter.webstandardsdays.ru/

Параметр поиска зашит в конфиге проксика, иначе мы быстро исчерпаем лимиты запросов.

Get-параметр fields определяет поля, которые мы хотим получить. Если его убрать — будет отдаваться полный объект твита, но зачем зря трафик туда-сюда гонять?

Fixed #72
