### PR TITLE
Исправил url для фейсбука на страницах Киева и Минска

### DIFF
--- a/2013/10/19/index.htm
+++ b/2013/10/19/index.htm
@@ -5,7 +5,7 @@
 	<meta charset="UTF-8">
 	<meta name="twitter:card" content="summary">
 	<meta name="twitter:site" content="@webstandards_ru">
-	<meta property="og:url" content="http://webstandardsdays.ru/2013/06/08/">
+	<meta property="og:url" content="http://webstandardsdays.ru/2013/10/19/">
 	<meta property="og:title" content="Встреча Web Standards Days в Минске 19 октября 2013 года">
 	<meta property="og:description" content="Встреча веб-разработчиков, целью которой является обмен опытом и широкое внедрение веб-стандартов в процесс разработки. Участие бесплатное">
 	<meta property="og:image" content="http://webstandardsdays.ru/i/header.png">

--- a/2013/10/26/index.htm
+++ b/2013/10/26/index.htm
@@ -5,7 +5,7 @@
 	<meta charset="UTF-8">
 	<meta name="twitter:card" content="summary">
 	<meta name="twitter:site" content="@webstandards_ru">
-	<meta property="og:url" content="http://webstandardsdays.ru/2013/06/08/">
+	<meta property="og:url" content="http://webstandardsdays.ru/2013/10/26/">
 	<meta property="og:title" content="Встреча Web Standards Days в Киеве 26 октября 2013 года">
 	<meta property="og:description" content="Встреча веб-разработчиков, целью которой является обмен опытом и широкое внедрение веб-стандартов в процесс разработки. Участие бесплатное">
 	<meta property="og:image" content="http://webstandardsdays.ru/i/header.png">


### PR DESCRIPTION
Вставил url в метатеги опенграфа, но на http://master.webstandardsdays.ru/ фейсбук всё равно ведёт себя как придётся.
