### PR TITLE
Показываем счётчик числа поданных заявок

### DIFF
--- a/2014/06/28/index.html
+++ b/2014/06/28/index.html
@@ -261,6 +261,7 @@
 					<a href="#main" title="Наверх" class="top">Наверх</a>
 				</header>
 				<iframe src="https://docs.google.com/forms/d/1YEAnwD9i1Jk1KTgB1iWXKEFItMuXTHkAqQ3QFgVdeDo/viewform?embedded=true" scrolling="no" height="680" class="register-form">Загрузка…</iframe>
+                <p>Уже подано <span class="registration-counter"></span>.</p>
 			</article>
 			<article id="location" class="article">
 				<header>

--- a/j/script.js
+++ b/j/script.js
@@ -99,7 +99,25 @@ $(function(){
         });
 	};
 
+    $.fn.registrationCounter = function() {
+        var $this = $(this);
+
+        function declOfNum(number, titles) {
+            var cases = [2, 0, 1, 1, 1, 2];
+            return titles[ (number % 100 > 4 && number % 100 < 20)? 2 : cases[ ( number % 10 < 5 ) ? number % 10 : 5] ];
+        }
+
+        $.getJSON('http://api.webstandardsdays.ru/', function(data) {
+            var count = parseInt(data.registered);
+            var postfix = declOfNum(count, ['заявка', 'заявки', 'заявок']);
+
+            $this.text(count + ' ' + postfix);
+        });
+    };
+
 	$('#map').yandexMap();
+
+    $('.registration-counter').registrationCounter();
 
 	// Donate
 


### PR DESCRIPTION
@pepelsbey я тут развлёкся на ночь глядя, и снова запилил парсилку количества регистраций на питерский ВСД. Только теперь на ноде. Сейчас там один-единственный эндпойнт, да больше и не надо: http://api.webstandardsdays.ru/

Всё это богатство я завернул в jQuery-плагин, который выводит под формой регистрации строчку: _Уже подано ХХХ заявки_ (сколнения есть, как полагается).

Код парсилки тут: https://github.com/h4/wsd-registration
