### PR TITLE
Добавил забытую точнку с запятой

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,7 +11,7 @@ var autoprefixer = require('gulp-autoprefixer'),
 var paths = {
 	html: 'src/**/*.html',
 	styles: 'src/styles/*.scss'
-}
+};
 
 gulp.task('default', ['copy', 'html', 'styles'], function () {
 	sync.init({


### PR DESCRIPTION
Раз уж у нас бест-практис, то пусть они будут везде ;)

Ещё у меня сомнения, что `.pipe(sass().on('error', sass.logError))` работает. Если выкинуть эту строку и сломать scss-файл, то будет точно такой же результат, как если бы этой строчки не было. Но, повторюсь, я в галпе полный профан.