### PR TITLE
Fix site in IE11

### DIFF
--- a/src/styles/reset.scss
+++ b/src/styles/reset.scss
@@ -27,7 +27,7 @@ time, mark, audio, video {
 	vertical-align:baseline;
 	}
 article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
+footer, header, hgroup, main, menu, nav, section, summary {
 	display:block;
 	}
 body {


### PR DESCRIPTION
 * Correct `block` display not defined for any HTML5 element in IE 8/9.
 * Correct `block` display not defined for `details` or `summary` in IE 10/11
 * and Firefox.
 * Correct `block` display not defined for `main` in IE 11.