### PR TITLE
Fix donate form on Kyiv-2016 WSD page

### DIFF
--- a/src/pages/2016-11-26-kiev.html
+++ b/src/pages/2016-11-26-kiev.html
@@ -54,7 +54,8 @@
 					<input type="hidden" name="targets" value="Поддержка «Веб-стандартов»">
 					<input type="hidden" name="quickpay-form" value="donate">
 					<input type="hidden" name="paymentType" value="AC">
-					<input elem="amount" name="sum" value="500" size="4" required type="text">
+					<input elem="amount" name="sum" value="490" size="4" required type="hidden">					
+					<input elem="amount" value="199 ₴" size="4" type="text" readonly>
 					<button elem="button" mix="block:button">Поддержать</button>
 				</form>
 			</div>

--- a/src/pages/2016-11-26-kiev.html
+++ b/src/pages/2016-11-26-kiev.html
@@ -54,8 +54,8 @@
 					<input type="hidden" name="targets" value="Поддержка «Веб-стандартов»">
 					<input type="hidden" name="quickpay-form" value="donate">
 					<input type="hidden" name="paymentType" value="AC">
-					<input elem="amount" name="sum" value="490" size="4" required type="hidden">					
-					<input elem="amount" value="199 ₴" size="4" type="text" readonly>
+					<input elem="amount" name="sum" value="476" size="4" required type="hidden">					
+					<input elem="amount" value="200 ₴" size="6" type="text" readonly>
 					<button elem="button" mix="block:button">Поддержать</button>
 				</form>
 			</div>


### PR DESCRIPTION
Replace RUB with UAH.
Hardcode is bad, but its better that currect state with sum in RUB what ALL will missunderstanding as UAH value (what is 3 times bigger).
In general, someday we shall have to replace the form of donations for the Kiev conference to LiqPay.